### PR TITLE
NIT: normalize gitattributes and nuget.config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+*.nupkg   binary
+*.snupkg  binary
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 *.sln    merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,22 @@
-* -text
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
+
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="localhost-custom-nugets" value="custom-nugets/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Hello,

nothing very important:

### changes list
* copy paste `.gitattributes` from https://github.com/github/VisualStudio/blob/master/.gitattributes
* add `binary` for both `nupkg` and `snupkg`
* clear inherited feed from user profile with a `<clear />`
* explicitly add `nuget.org` to the list

### reason for nuget.config changes:
for a weird reason the nuget feed is globally added to user profile and magically works on dev box but is not a friendly approach at all for CI.
this change is just a bit picking as long as anyone using it "magically rely on user profile feeds being auto imported"

### reason for `.gitattributes` changes:
letting git treat known text file or source code as text for better diff diff experience during commits / merge / rebase / conflict resolution

and only be explicit on what should not be treated as "text" => we're making sure that `(s)nupkg` are seen as binary files and git won't try to "be smart" on `git add` or `git checkout` by eliminating possible `[CR] [LF]` successive char and replacing them with `[LF]`
this replacement is intended to exist for a good reason when delaingn with text file and IDE